### PR TITLE
Display check-in count from BatchRegistry contract

### DIFF
--- a/packages/nextjs/app/page.tsx
+++ b/packages/nextjs/app/page.tsx
@@ -3,8 +3,14 @@
 import Link from "next/link";
 import type { NextPage } from "next";
 import { BugAntIcon, MagnifyingGlassIcon } from "@heroicons/react/24/outline";
+import { useScaffoldReadContract } from "~~/hooks/scaffold-eth";
 
 const Home: NextPage = () => {
+  const { data: checkedInCount, isLoading } = useScaffoldReadContract({
+    contractName: "BatchRegistry",
+    functionName: "checkedInCounter",
+  });
+
   return (
     <>
       <div className="flex items-center flex-col grow pt-10">
@@ -16,7 +22,7 @@ const Home: NextPage = () => {
           <p className="text-center text-lg">Get started by taking a look at your batch GitHub repository.</p>
           <p className="text-lg flex gap-2 justify-center">
             <span className="font-bold">Checked in builders count:</span>
-            <span>To Be Implemented</span>
+            <span>{isLoading ? "Loading..." : checkedInCount?.toString() || "0"}</span>
           </p>
         </div>
 

--- a/packages/nextjs/next-env.d.ts
+++ b/packages/nextjs/next-env.d.ts
@@ -1,5 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
+/// <reference path="./.next/types/routes.d.ts" />
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
## What's this about?
The homepage had "To Be Implemented" text for the builder count. Now it actually shows the real number from the smart contract

## Changes
- Used the `useScaffoldReadContract` hook to read `checkedInCounter` from BatchRegistry
- Added a loading state so users see "Loading..." while data is being fetched
- Once loaded, it shows the actual count

Pretty simple change but now we can see how many builders have checked in 🎉

Closes #7
