### PR TITLE
feat: add new builder personal page 

### DIFF
--- a/packages/nextjs/.prettierrc.js
+++ b/packages/nextjs/.prettierrc.js
@@ -1,0 +1,9 @@
+module.exports = {
+  "arrowParens": "avoid",
+  "printWidth": 120,
+  "tabWidth": 2,
+  "trailingComma": "all",
+  "importOrder": ["^react$", "^next/(.*)$", "<THIRD_PARTY_MODULES>", "^@heroicons/(.*)$", "^~~/(.*)$"],
+  "importOrderSortSpecifiers": true,
+  "plugins": [require.resolve("@trivago/prettier-plugin-sort-imports")],
+}

--- a/packages/nextjs/postcss.config.js
+++ b/packages/nextjs/postcss.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  plugins: {
+    '@tailwindcss/postcss': {},
+  },
+};


### PR DESCRIPTION
## Description

This PR adds my personal builder page for Batch 22 of BuidlGuidl. The page features:

- **Two-card layout** with profile information and "About Me" section
- **Gradient title** with custom styling using accent, info, and success colors
- **Avatar** with "CD" initials in a gradient circle
- **Social links** with GitHub and Twitter buttons (with SVG icons)
- **Responsive design** that adapts to mobile and desktop views
- **Enhanced styling** with shadows, borders, and hover effects
- **TypeScript** with proper NextPage typing

The page is located at `/builders/0x3Be7fbBDbC73Fc4731D60EF09c4BA1A94DC58E41` and includes:

- Welcome section with gradient title
- Profile card with avatar, address, bio, and social links
- About Me card with sections for Learning, Interests, and Goals

## Screenshots
<img width="1920" height="1080" alt="Screenshot from 2025-12-01 14-58-03" src="https://github.com/user-attachments/assets/f8278e9b-df8a-4aa2-8128-c34b6a7e8708" />
<img width="1920" height="1080" alt="Screenshot from 2025-12-01 15-04-23" src="https://github.com/user-attachments/assets/d8bda860-334c-455f-a1e8-80749e8d1d32" />

## Related Issues

Closes #10

Your ENS/address:
0x3Be7fbBDbC73Fc4731D60EF09c4BA1A94DC58E41
