### PR TITLE
Add personal builder page for Khano

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,4 +21,3 @@ node_modules
 
 # cli
 dist
-.vercel

--- a/packages/nextjs/app/layout.tsx
+++ b/packages/nextjs/app/layout.tsx
@@ -10,7 +10,7 @@ export const metadata = getMetadata({
   description: "Built with 🏗 Scaffold-ETH 2",
 });
 
-export default function RootLayout({ children }: { children: React.ReactNode }) {
+const ScaffoldEthApp = ({ children }: { children: React.ReactNode }) => {
   return (
     <html suppressHydrationWarning>
       <body>
@@ -20,4 +20,6 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
       </body>
     </html>
   );
-}
+};
+
+export default ScaffoldEthApp;


### PR DESCRIPTION
Personal Builder Page – Khano

Closes #21

This PR adds my personal builder page to the Batch 22 website.
It includes:

my avatar

my Web3 bio

my wallet address (via Scaffold UI Address component)

my relevant social links

I followed the builder page structure and styling conventions used by other contributors.

 Screenshots
<img width="1357" height="604" alt="image" src="https://github.com/user-attachments/assets/7f9fe016-1f4a-47de-b26d-3e38496fa01e" />

<img width="1353" height="606" alt="image" src="https://github.com/user-attachments/assets/eee1ad14-9d54-46cf-958a-cb9705c2888b" />

<img width="369" height="509" alt="image" src="https://github.com/user-attachments/assets/7e53e7c7-7625-4006-b79c-793931466059" />

