### PR TITLE
Display the number of checked-in builders

### DIFF
--- a/packages/nextjs/app/page.tsx
+++ b/packages/nextjs/app/page.tsx
@@ -3,8 +3,14 @@
 import Link from "next/link";
 import type { NextPage } from "next";
 import { BugAntIcon, MagnifyingGlassIcon } from "@heroicons/react/24/outline";
+import { useScaffoldReadContract } from "~~/hooks/scaffold-eth";
 
 const Home: NextPage = () => {
+  const { data: checkedInCounter, isSuccess: isCheckedInCounterSuccess } = useScaffoldReadContract({
+    contractName: "BatchRegistry",
+    functionName: "checkedInCounter",
+  });
+
   return (
     <>
       <div className="flex items-center flex-col grow pt-10">
@@ -16,7 +22,11 @@ const Home: NextPage = () => {
           <p className="text-center text-lg">Get started by taking a look at your batch GitHub repository.</p>
           <p className="text-lg flex gap-2 justify-center">
             <span className="font-bold">Checked in builders count:</span>
-            <span>To Be Implemented</span>
+            {isCheckedInCounterSuccess ? (
+              <span>{checkedInCounter ? checkedInCounter.toString() : 0}</span>
+            ) : (
+              <span className="loading loading-spinner"></span>
+            )}
           </p>
         </div>
 


### PR DESCRIPTION
## Description

I mostly followed the [recipe for reading from a contract in the Scaffold docs](https://docs.scaffoldeth.io/recipes/ReadUintFromContract). However, when I used the public Arbitrum network I was getting pretty long periods where I would get the default value displayed, and then it would display the spinner, and then display the actual value. I haven't used Wagmi and TanStack too much before, but it appears isLoading only covers when the request is literally inflight - so not the period before when the query is issued and other state is being setup. At least that was my take away from this [discussion in the TanStack issues about isLoading vs isPending](https://github.com/TanStack/query/discussions/6297)

And even with isPending it only covers the success case. If I swapped to isPending and handled the rest the same the page would incorrectly show 0 check-ins if there was an error. So instead I used the Wagmi versions and check for isSuccess instead. If there's an error it now just leaves the spinner forever. But I felt that was more accurate than letting it default to 0.

## Additional Information

- [x] I have read the [contributing docs](/scaffold-eth/scaffold-eth-2/blob/main/CONTRIBUTING.md) (if this is your first contribution)
- [x] This is not a duplicate of any [existing pull request](https://github.com/scaffold-eth/scaffold-eth-2/pulls)

## Related Issues

_Closes #7_

Your ENS/address: mikerowehl.eth (0x9c9234420501c820f73cfA44e822D27e1baAb4D5)
